### PR TITLE
IDVA6-1941: Updated dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,15 +21,20 @@
         <maven.compiler.target>21</maven.compiler.target>
 
         <!-- Dependency Versions -->
-        <ch-kafka.version>3.0.0</ch-kafka.version>
-        <kafka-models.version>3.0.0</kafka-models.version>
-        <jackson.version.core>2.15.2</jackson.version.core>
-        <jackson.version.databind>2.15.2</jackson.version.databind>
-        <spring-framework.version>6.0.9</spring-framework.version>
+        <ch-kafka.version>3.0.2</ch-kafka.version> <!-- latest that works. 3.0.3 does not work -->
+        <kafka-models.version>3.0.8</kafka-models.version>
+        <spring-framework.version>6.2.0</spring-framework.version>
+        <jackson.version.core>2.18.1</jackson.version.core>
+        <jackson.version.databind>2.18.1</jackson.version.databind>
+        <avro.version>1.12.0</avro.version>
+        <json-path.version>2.9.0</json-path.version>
+        <http2-server.version>11.0.24</http2-server.version>
+        <guava.version>33.3.1-jre</guava.version>
+        <commons-fileupload.version>1.5</commons-fileupload.version>
 
         <!-- Testing -->
         <junit.version>4.13.2</junit.version>
-        <mockito.version>5.5.0</mockito.version>
+        <mockito.version>5.14.2</mockito.version>
 
         <!-- Sonar -->
         <sonar.coverage.exclusions>
@@ -54,7 +59,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.11.3</version>
+            <version>${avro.version}</version>
         </dependency>
 
         <dependency>
@@ -98,17 +103,17 @@
         <dependency>
             <groupId>org.eclipse.jetty.http2</groupId>
             <artifactId>http2-server</artifactId>
-            <version>11.0.16</version>
+            <version>${http2-server.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.1.2-jre</version>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.5</version>
+            <version>${commons-fileupload.version}</version>
         </dependency>
         <dependency>
 	        <groupId>org.springframework</groupId>


### PR DESCRIPTION
### 1.0) Overview
`email-producer-java`'s dependencies have grown stale, and this might be a potential source of security vulnerabilities. The purpose of this PR is to update all of the dependencies to the latest versions.

Was able to update everything to latest version, except for `ch-kafka`. Version 3.0.2 works correctly, but Version 3.0.3 results in an `UnsupportedVersionException`. Updating kafka-clients did not resolve issue.

### 2.0) Testing

Used the `acsp-manage-users-api` to drive tests. In particular, changed the `email-producer-java` version in `acsp-manage-users-api` to `unversioned`. Then ran the acsp-manage-users-api locally with varying environments by adjusting `application.properties`. For example for CI-DEV, setting `kafka.broker.addr=${KAFKA_BROKER_ADDR}` to `kafka.broker.addr=kafka-broker1-cidev.development.aws.internal:9092`.

**2.1) CI-DEV**

First attempted to run the `acsp-manage-users-api` without any changes to `email-producer-java`. Successfully sent notification. **Test passed**.

Then attempted to run the `acsp-manage-users-api` with PR changes to `email-producer-java`. Successfully sent notification. **Test passed**.

**2.2) Phoenix1**

Attempted to run the `acsp-manage-users-api` without any changes to `email-producer-java`. This was working yesterday, but is not working today. Isolated problem to `kafka.broker.addr=kafka-broker1-phoenix1.development.aws.internal:9092`. Unable to connect to Phoenix1 - so unable to verify. _Double-checked Phoenix1 (not local) and notifications are being sent there - so this is a local development environment issue_. **Test Result Unknown.**

Because I can't connect to Phoenix1, I can't test the PR in Phoenix1 environment. **Test Result Unknown.**

**2.3) chs-dev**

Attempted to run the `acsp-manage-users-api` without any changes to `email-producer-java`. The `acsp-manage-users-api` successfully throws message onto Kafka Queue. The `chs-notification-api` retrieves the message successfully. Suggests that email producer and consumer are working together correctly. However, `chs-notification-api` can't find template even though it is definitely there. Looks like unrelated bug. **Test Partially Passed.**

Repeated above test with PR changes. Same result. **Test Partially Passed.**