### PR TITLE
[CC-2767] Upgrade dependencies to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
 
         <!-- Dependency Versions -->
         <ch-kafka.version>3.0.6</ch-kafka.version>
-        <kafka-models.version>3.0.20</kafka-models.version>
-        <spring-framework.version>6.2.8</spring-framework.version>
+        <kafka-models.version>3.0.21</kafka-models.version>
+        <spring-framework.version>6.2.10</spring-framework.version>
         <jackson.version.core>2.18.1</jackson.version.core>
         <jackson.version.databind>2.18.1</jackson.version.databind>
         <avro.version>1.12.0</avro.version>
@@ -33,7 +33,7 @@
         <guava.version>33.3.1-jre</guava.version>
         <commons-fileupload.version>2.0.0-M4</commons-fileupload.version>
         <google-gson.version>2.13.1</google-gson.version>
-        <jetty-http2-common.version>12.0.23</jetty-http2-common.version>
+        <jetty-http2-common.version>12.1.0</jetty-http2-common.version>
         <!-- Testing -->
         <junit.version>4.13.2</junit.version>
         <mockito.version>5.14.2</mockito.version>


### PR DESCRIPTION
   - updated spring-core version to 6.2.10 to fix CVE-2025-41242
   - updated jetty-http2-common version to 12.1.0 to fix CVE-2025-5115
   - updated kafka-models version to 3.2.1